### PR TITLE
Update address_encoding.rst

### DIFF
--- a/docs/address_encoding.rst
+++ b/docs/address_encoding.rst
@@ -61,15 +61,16 @@ Example code: encode_base40()
      uint64_t encoded = 0;
      for (const char *p = (callsign + strlen(callsign) - 1); p >= callsign; p-- ) {
        encoded *= 40;
-       // If speed is more important than code space, you can replace this with a lookup into a 256 byte array.
+       // If speed is more important than code space, 
+       // you can replace this with a lookup into a 256 byte array.
        if (*p >= 'A' && *p <= 'Z') // 1-26
          encoded += *p - 'A' + 1;
        else if (*p >= '0' && *p <= '9') // 27-36
          encoded += *p - '0' + 27;
        else if (*p == '-') // 37
          encoded += 37;
-       // These are just place holders. If other characters make more sense, change these.
-       // Be sure to change them in the decode array below too.
+       // These are just place holders. If other characters make more sense,
+       // change these. Be sure to change them in the decode array below too.
        else if (*p == '/') // 38
          encoded += 38;
        else if (*p == '.') // 39


### PR DESCRIPTION
Some fixes to clean up the A.1.1 rendering in the PDF. Basically bringing the code comments for the python example into PEP8 <80chars per line.