### PR TITLE
Provide binary value for hex encoded value to decrease mental load

### DIFF
--- a/docs/physical_layer.rst
+++ b/docs/physical_layer.rst
@@ -46,7 +46,7 @@ The bit-to-symbol mapping is shown in the table below.
 
 .. todo:: update section
 
-The most significant bits are sent first, meaning that the byte 0xB4
+The most significant bits are sent first, meaning that the byte 0xB4 (= 0b10'11'01'00)
 in type 4 bits (see :ref:`bit_types`) would be sent as the symbols -1 -3 +3
 +1.
 


### PR DESCRIPTION
This is really a very small improvement, but I found it hard in my head to map from the hex constant `0xB4` into 8 binary values and then further segmenting them into groups of 2 followed by doing a table-lookup.