### PR TITLE
Simplify and correct encryption documentation

### DIFF
--- a/docs/application_layer.rst
+++ b/docs/application_layer.rst
@@ -153,19 +153,33 @@ algorithm.  Figures 5 to 8 show block diagrams of the algorithm
    24-bit LFSR taps
 
 
+.. warning::
+    Scrambler "Encryption" is not even remotely secure. LFSR's are entirely 
+    reverseable: once an attacker knows even a little key stream, they can easily 
+    determine the entire state of the LFSR, which allows them to generate all
+    keystream going forward and backward in time.  LFSR states of 8, 16, or even 24 bits
+    are trivially brute-forceable.  This is little more than obfuscation to keep
+    out only the listeners who don't really care.  Anyone who wants to can break into
+    a "Scrambled" stream in real time.
+
 Advanced Encryption Standard (AES)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Encryption type = :math:`10_2`
 
-This method uses AES block cipher in counter (CTR) mode, with a 96-bit
-nonce that should never be used for more than one separate stream and a 32 bit CTR.
+This method uses AES-128 block cipher in counter (CTR) mode.  CTR mode
+requires one block of an IV (Initialization Vector, 128 bits) that is made up
+of a 112-bit random nonce, padded to the LSB with zeros.  This 112-bit 
+nonce value is provided in the META field.
 
-The 96-bit AES nonce value is extracted from the 96 most significant
-bits of the META field, and the remaining 16 bits of the META field
-form the highest 16 bits of the 32 bit counter.  The FN (Frame Number)
-field value is then used to fill out the lower 16 bits of the counter,
-and always starts from 0 (zero) in a new voice stream.
+**FIXME** Key negotiation? The IV and Keys are different things; using a fixed
+key and random IV is not secure.
+
+The counter is provided in the FN (Frame Number) field, and always starts 
+from 0 (zero) in a new voice stream.  The IV is added to the FN to form the
+full Counter in the CTR mode.  Since the 16 LSB in the IV are zero padding,
+and the FN is only ever 15 bits, this operation can also be performed by
+concatenation instead of addition.
 
 The 16 bit frame number and 40 ms frames can provide for over 20 minutes
 of streaming without rolling over the counter [#fn_roll]_.
@@ -176,28 +190,19 @@ of streaming without rolling over the counter [#fn_roll]_.
               2**15 frames / 25 frames per second = 1310 seconds, or 21
               minutes and some change.
 
-The random part of the nonce value should be generated with a hardware
-random number generator or any other method of generating non-repeating
-values. 
+The security of the system depends on the quality of random numbers used.
+The best source of entropy available should be used, ideally a proper
+Psudo Random Number Generator algorithm (eg: FIPS SP800-90B [PRNG]_)
+that's been seeded with as much hardware based entropy as possible.
 
-To combat replay attacks, a 32-bit timestamp shall be embedded into the
-cryptographic nonce field. The field structure of the 96 bit nonce is
-shown in Table 9. Timestamp is 32 LSB portion of the number of seconds
-that elapsed since the beginning of 1970-01-01, 00:00:00 UTC, minus leap
-seconds (a.k.a. “unix time”).
-
-.. list-table:: 96 bit nonce field structure
+.. list-table:: 128 bit CTR mode "Counter" structure
    :header-rows: 1
 
-   * - TIMESTAMP
-     - RANDOM DATA
-     - CTR_HIGH
-   * - 32
-     - 64
+   * - Random Nonce from META field.
+     - Frame Number
+   * - 96
      - 16
 
-**CTR_HIGH** field initializes the highest 16 bits of the CTR, with
-the rest of the counter being equal to the FN counter.
 
 .. warning::
     In CTR mode, AES encryption is malleable [CTR]_ [CRYPTO]_.
@@ -212,3 +217,5 @@ the rest of the counter being equal to the FN counter.
 .. [CTR] McGrew, David A. "Counter mode security: Analysis and recommendations." Cisco Systems, November 2, no. 4 (2002).
 
 .. [CRYPTO] Rogaway, Phillip. "Evaluation of some blockcipher modes of operation." Cryptography Research and Evaluation Committees (CRYPTREC) for the Government of Japan (2011).
+
+.. [PRNG] https://csrc.nist.gov/publications/detail/sp/800-90a/rev-1/final

--- a/docs/data_link_layer.rst
+++ b/docs/data_link_layer.rst
@@ -337,7 +337,7 @@ The packet superframe consists of 798 payload data bytes and a 2-byte CCITT CRC-
 Packet data is split into frames of 368 type 4 bits preceded by a packet-specific 16-bit sync
 word (0xFF5D).  This is the same size frame used by stream mode.
 
-The packet frame starts with a 210 byte frame of type 1 data.  It is noteworthy that it does
+The packet frame starts with a 210 bit frame of type 1 data.  It is noteworthy that it does
 not terminate on a byte boundary.
 
 The frame has 200 bits (25 bytes) of payload data, 6 bits of frame metadata, and 4 bits to


### PR DESCRIPTION
**Scrambler "encryption"** is laughably insecure. At best, it'll keep out anyone who was only curious and doesn't want to put in any effort. Anyone who actually cares can break that in real time.  I still think there's value in that, so I'm not proposing we remove it from the spec, but I do think it warrants a warning.  Ideally, we'd replace the LFSRs with something better, such as SP800-90A as mentioned in the AES section below.

**AES-128 in CTR mode** can be done right, but this isn't quite there yet.  My thoughts reading the current document:
* IV and Keys are different things, and we need both. Having a good random IV is not a substitute for having a good key; the IV is sent over the wire!  The document needs to describe how the keys are negotiated: Pre-shared keys, or maybe a DH style key negotiation that happens using Packet modes.  Whatever it is, it should be described here, or described elsewhere and referenced here.
* The IV and Counter become one field in CTR mode. There's no point in splitting the 112-bit META into a 96-bit nonce and a 16-bit "top of counter" field.  All that does is make another 16 bits of the nonce predictable, might as well just make it all random.
* Same thing with the timestamp, it provides no value. A 112 bit random value is plenty large enough to make collisions negligible (see https://en.wikipedia.org/wiki/Birthday_problem. We'd need about 2^56 message streams with the same key to have a .5 chance of accidentally using the same IV twice.)  All it does is make more of the IV predictable.

So I simplified the IV to just the 112-bit random nonce, the entire META field, and the 16-bit counter from the Frame Number.

I'm happy to discuss more crypto if there are any follow-up questions.