### PR TITLE
Fix LICH CRC having been included in the bit count.

### DIFF
--- a/pages/04.appendix/04.ip-networking/docs.md
+++ b/pages/04.appendix/04.ip-networking/docs.md
@@ -25,7 +25,7 @@ Field          | Size     | Description
 -----          | ----     | -----------
 MAGIC          | 32 bits  | Magic bytes 0x4d313720 (“M17 “)
 StreamID (SID) | 16 bits  | Random bits, changed for each PTT or stream, but consistent from frame to frame within a stream
-LICH           | 240 bits | The meaningful contents of a LICH frame (dst, src, streamtype, META field, CRC16) as defined earlier.
+LICH           | 224 bits | The meaningful contents of a LICH frame (dst, src, streamtype, META field) as defined earlier.
 FN             | 16 bits  | Frame number (exactly as would be transmitted as an RF stream frame, including the last frame indicator at (FN & 0x8000)
 Payload        | 128 bits | Payload (exactly as would be transmitted in an RF stream frame)
 CRC16          | 16 bits  | CRC for the entire packet, as defined earlier [CRC definition](https://spec.m17project.org/part-1/data-link-layer#crc)


### PR DESCRIPTION
Based of current implementations and history of the protocol the LICH CRC appeared to have been accidentally counted in the bits.

As a source of the current implementation I looked at mrefd which M17-M17 is running on and found the following.
https://github.com/n7tae/mrefd/blob/fe88dd9fefd2b6c77b75b8c843d1f686dc40114e/packet.h#L33-L48

Which helped explain the inconsistency between the actual packet length and what the spec was saying it should be. 

I believe this error happened when the spec was updated from saying sizeof(LICH)*8 to actually having the bit number in the docs.