### PR TITLE
Clarify bit order in various binary structure definitions

### DIFF
--- a/M17_spec.tex
+++ b/M17_spec.tex
@@ -10,6 +10,8 @@
 \usepackage{tabularray}
 \usepackage{multirow}
 \usepackage{float}
+\usepackage{nicematrix}
+\NiceMatrixOptions{cell-space-top-limit=4pt, cell-space-bottom-limit=4pt}
 \usepackage{tikz}
 \usetikzlibrary{shapes.geometric, arrows.meta}
 \tikzstyle{textonly} = [rectangle,
@@ -487,28 +489,32 @@ Total: 240 Type 1 bits
 
 Destination and source addresses may be encoded amateur radio callsigns, or special numbers. See the Address Encoding Appendix for details.
 
-\subsection{LSF TYPE}
+\subsection{LSF TYPE} \label{lsftype}
 
 The TYPE field contains information about the frames to follow LSF. The Packet/Stream indicator bit determines which mode (Packet or Stream) will be used during the transmission. The remaining field meanings are defined by the specific mode and application.
 
 \begin{table}[H]
 	\centering
-	\begin{tblr}{
-		colspec={lX},
-		}
+	\small
+	\begin{NiceTabular}{|W{c}{4em}|[tikz=very thick]W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|}
 		\hline
-		Bits & Content \\
+		\diagbox{Byte}{Bit} & 7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+		\Hline[tikz=very thick]
+		0 &
+			\multicolumn{4}{c}{\textit{Reserved}} &
+			\parbox{3em}{\centering Signed Stream} &
+			\multicolumn{3}{c}{Channel Access Number\ldots} \\
 		\hline
-		0 & Packet/Stream indicator \\
-		1..2 & Data type indicator \\
-		3..4 & Encryption type \\
-		5..6 & Encryption subtype \\
-		7..10 & Channel Access Number (CAN) \\
-		11 & Stream signature available \\
-		12..15 & Reserved (don't care) \\
-		\hline[2px]
-	\end{tblr}
-	\caption{LSF TYPE definition}
+		1 &
+			\ldots &
+			\multicolumn{2}{c}{\parbox{6em}{\centering Encryption Subtype}} &
+			\multicolumn{2}{c}{\parbox{6em}{\centering Encryption Type}} &
+			\multicolumn{2}{c}{\parbox{6em}{\centering Data Type}} &
+			\parbox{3em}{\centering Packet/ Stream} \\
+		\hline
+	\end{NiceTabular}
+	\normalsize
+	\caption{LSF TYPE layout}
 \end{table}
 
 \begin{table}[H]
@@ -685,23 +691,22 @@ Each Stream Frame contains a 48-bit Link Information Channel (LICH). Each LICH w
 
 \begin{table}[H]
 	\centering
-	\begin{tblr}{
-		colspec={lX},
-		}
-		\hline
-		Bits & Content \\
-		\hline
-		0..39 & 40-bit chunk of full LSF Contents (Type 1 bits) \\
-		40..42 & LICH\_CNT \\
-		43..47 & Reserved \\
-		\hline[2px]
-	\end{tblr}
+	\small
+	\begin{NiceTabular}{|W{c}{4em}|[tikz=very thick]W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|}[hvlines]
+		\diagbox{Byte}{Bit} & 7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+		\Hline[tikz=very thick]
+		0 & \Block{3-8}{40-bit chunk of full LSF Contents (Type 1 bits)} \\
+		\ldots &  \\
+		4 & \\
+		5 & \multicolumn{3}{c}{LICH\_CNT} & \multicolumn{5}{c}{\textit{Reserved}} \\
+	\end{NiceTabular}
+	\normalsize
 	\caption{Link Information Channel Contents}
 \end{table}
 
 Total: 48 bits
 
-The 40-bit chunks start with the most significant byte of the LSF.
+The 40-bit chunks start from the beginning of the LSF.
 
 \begin{table}[H]
 	\centering
@@ -711,12 +716,12 @@ The 40-bit chunks start with the most significant byte of the LSF.
 		\hline
 		LICH\_CNT & LSF bits \\
 		\hline
-		0 & 239:200 \\
-		1 & 199:160 \\
-		2 & 159:120 \\
-		3 & 119:80 \\
-		4 & 79:40 \\
-		5 & 39:0 \\
+		0 & 0:39 \\
+		1 & 40:79 \\
+		2 & 80:119 \\
+		3 & 120:159 \\
+		4 & 160:199 \\
+		5 & 200:239 \\
 		\hline[2px]
 	\end{tblr}
 	\caption{LICH\_CNT and LSF bits}
@@ -899,15 +904,19 @@ Packet Frames contain Packet Contents after ECC/FEC is applied.
 
 \begin{table}[H]
 	\centering
-	\begin{tblr}{ll}
-		\hline
-		Bits & Meaning \\
-		\hline
-		0..199 & 200-bit chunk of Single Packet \\
-		200 & End of Frame (EOF) indicator \\
-		201..205 & Packet Frame/Byte Counter \\
-		\hline[2px]
-	\end{tblr}
+	\small
+	\begin{NiceTabular}{|W{c}{4em}|[tikz=very thick]W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|}[hvlines]
+		\diagbox{Byte}{Bit} & 7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+		\Hline[tikz=very thick]
+		0 & \Block{3-8}{200-bit chunk of Single Packet} \\
+		\ldots &  \\
+		24 & \\
+		25 &
+			\parbox{3em}{\centering End of Frame} &
+			\multicolumn{5}{c}{Packet Frame/Byte Counter} &
+			\Block[fill=gray]{1-2}{} & \\
+	\end{NiceTabular}
+	\normalsize
 	\caption{Packet Contents}
 \end{table}
 
@@ -923,31 +932,31 @@ When there are no bytes remaining in the Packet Data after removing a 25-byte (o
 
 \begin{table}[H]
 	\centering
-	\begin{tblr}{
-		colspec={lX},
-		}
-		\hline
-		Bits & Meaning \\
-		\hline
-		0..4 & Frame number, 0..31 \\
-  		5 & Set to 0, Not end of frame \\
-		\hline[2px]
-	\end{tblr}
+	\small
+	\begin{NiceTabular}{|W{c}{4em}|[tikz=very thick]W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|}[hvlines]
+		\diagbox{Byte}{Bit} & 7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+		\Hline[tikz=very thick]
+		0 &
+			0 &
+			\multicolumn{5}{c}{Frame number, 0..31} &
+			\Block[fill=gray]{1-2}{} & \\
+	\end{NiceTabular}
+	\normalsize
 	\caption{Packet Metadata Field with EOF = 0}
 \end{table}
 
 \begin{table}[H]
 	\centering
-	\begin{tblr}{
-		colspec={lX},
-		}
-		\hline
-		Bits & Meaning \\
-		\hline
-		0..4 & Number of bytes in frame, 1..25 \\
-  		5 & Set to 1, End of frame \\
-		\hline[2px]
-	\end{tblr}
+	\small
+	\begin{NiceTabular}{|W{c}{4em}|[tikz=very thick]W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|W{c}{3em}|}[hvlines]
+		\diagbox{Byte}{Bit} & 7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+		\Hline[tikz=very thick]
+		0 &
+			1 &
+			\multicolumn{5}{c}{Number of bytes in frame, 1..25} &
+			\Block[fill=gray]{1-2}{} & \\
+	\end{NiceTabular}
+	\normalsize
 	\caption{Packet Metadata Field with EOF = 1}
 \end{table}
 
@@ -1133,30 +1142,23 @@ The destination address used by a client may simply be a callsign or reflector d
 
 \paragraph{TYPE field}
 
-The TYPE field contains information about the frames to follow LSF.
+The TYPE field contains information about the frames to follow LSF. For full definition see Section \ref{lsftype}.
 
 \begin{table}[H]
 	\centering
 	\begin{tblr}{ll}
 		\hline
-		Bits & Meaning \\
+		Packet/Stream & 1 = Stream Mode \\
 		\hline
-		0 & Packet/Stream indicator \\
-		& 1 = Stream Mode \\
+		Data Type & $10_2$ = Voice only (3200 bps) \\
 		\hline
-		1..2 & Data type indicator \\
-		& $10_2$ = Voice only (3200 bps) \\
-		\hline
-		3..4 & Encryption type \\
-		& $00_2$ = None \\
+		Encryption Type & $00_2$ = None \\
 		& $01_2$ = Scrambling \\
 		& $10_2$ = AES \\
 		\hline
-		5..6 & Encryption subtype \\
+		Encryption Subtype & Depends on Encryption Type \\
 		\hline
-		7..10 & Channel Access Number (CAN) \\
-		\hline
-		11..15 & Reserved (don't care) \\
+		Channel Access Number (CAN) & 0..15 \\
 		\hline[2px]
 	\end{tblr}
 	\caption{M17 Voice LSF TYPE definition}


### PR DESCRIPTION
Closes #147. Rendered version: [M17_spec.pdf](https://github.com/user-attachments/files/18502111/M17_spec.pdf)

I have added the `nicematrix` package to help with drawing these tables. On Debian-based systems this is included in `texlive-science`.

## LSF TYPE

Before - it switches to counting bits from the right

![image](https://github.com/user-attachments/assets/21f5881c-d422-4731-9ffe-98bfed061ced)

After

![image](https://github.com/user-attachments/assets/25584eb1-6191-4d05-83c3-b29171edbb4a)

## LICH

Before - LSF chunks are described counting where bit 0 is the last one

![image](https://github.com/user-attachments/assets/c84e9f3f-a3cf-4ab3-9430-f702aadbbbcd)

After - LSF type 1 bits are counted left-to-right from 0

![image](https://github.com/user-attachments/assets/d583f81e-743f-4931-b282-8460a06c8ae2)

## Full packet frames

Before

![image](https://github.com/user-attachments/assets/ab1a5237-b147-4059-96a9-f846ebf5faa5)

After - clearer visualisation

![image](https://github.com/user-attachments/assets/fdbadeb2-c9db-4968-8218-3cfd32995160)

## Packet metadata

Before - counting bits from the right

![image](https://github.com/user-attachments/assets/829f5e55-eba1-478f-8cbb-db9ccc931b69)

After - show it in the same byte context as the full diagram, so there is limited opportunity to get confused

![image](https://github.com/user-attachments/assets/5fc4c90d-cae9-4ef5-a9aa-f9d6b84da71c)

## LSF for Voice Application

Before - duplicating much of the earlier LSF definition with the same counting from the right

![image](https://github.com/user-attachments/assets/1135eb83-752c-4092-a0f9-114ec982857e)

After - refer back to the earlier definition and focus on the values chosen for this application

![image](https://github.com/user-attachments/assets/f06518d6-8b20-43d8-98c9-aec9cc8a223c)
