### PR TITLE
Expand slightly on the UTF-8 encoding for packet data type

### DIFF
--- a/M17_spec.tex
+++ b/M17_spec.tex
@@ -1482,7 +1482,7 @@ Packets are sent using Packet Mode.
 
 A Stream Mode Transmission begins with an LSF.
 
-Packets are composed of a 1..n byte data type specifier and up to $823-n$ bytes of payload data. The data type specifier is encoded in the same way as UTF-8. It provides efficient coding of common data types. And it can be extended to include a very large number of distinct packet data type codes.
+Packets are composed of a 1..n byte data type specifier and up to $823-n$ bytes of payload data. The data type specifier is a variable-length encoding using the same format as UTF-8. The data type specifier must be between $0$ and $2^{21}-1$ which will occupy between 1 and 4 bytes when encoded. Values from 0 to 127 are identical to their encoded form.
 
 The data type specifier can also be used as a protocol specifier. For example, the following protocol identifiers are reserved in the M17 packet spec:
 


### PR DESCRIPTION
There was some feedback in #copywriting that the UTF-8 encoding of the data type wasn't very clear. I've suggested some changes here:

* state some basic parameters of the encoding so the reader knows roughly what to expect without having to go and look up UTF-8
* at the same time, avoid getting into the weeds by spelling out the byte prefixes
* clarify that M17 permits any value that fits (it does, right?) whereas unicode code points have a gap between 0xD7FF and 0xE000 and don't take values above 0x10FFFF