### PR TITLE
fix deploy and create PR preview

### DIFF
--- a/.github/workflows/generate_pdf.yml
+++ b/.github/workflows/generate_pdf.yml
@@ -55,7 +55,6 @@ jobs:
         uses: actions/deploy-pages@v4
 
       - name: Post URL to Summary
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo "🚀 [View the latest PDF](https://m17-project.github.io/M17_spec/M17_spec.pdf)" >> $GITHUB_STEP_SUMMARY
 
   # runs on PRs and non-main branch pushes


### PR DESCRIPTION
Fixes all automatic PDF build & deploy issues. I tested all the parts of this in my own fork.

* For branches or pull requests this will generate the PDF and upload the artifact. Unfortunately this is always a ZIP file found in the build action, but it's still a good preview.

* For merges to main it will build the spec and upload to pages. [You can see it uploaded to my own pages here](https://teque5.github.io/M17_spec/M17_spec.pdf).