### PR TITLE
V3 first draft

### DIFF
--- a/M17_spec.tex
+++ b/M17_spec.tex
@@ -1257,7 +1257,7 @@ The most significant 4 bits of the second byte of TYPE specifies the contents of
 	\label{tab:meta_type_subfield}
 \end{table}
 
-All META values use a single META block to carry data, except for Text Data, where up to 15 consecutive META arrays can be used to carry up to 195 bytes of Text Data. Of course because Packet Mode does not support encryption, it's value should never be \texttt{0xF}. Also, the only text data than can be supported would be a single block text, with a control byte of \texttt{0x11}.
+All META values use a single META block to carry data, except for Text Data, where up to 15 consecutive META arrays can be used to carry up to 195 bytes of Text Data. Of course because Packet Mode does not support encryption, its value should never be \texttt{0xF}. Also, the only text data than can be supported would be a single block text, with a control byte of \texttt{0x11}.
 
 \subsection{CAN}
 


### PR DESCRIPTION
A first draft of V3.0.0 and the new TYPE format, based on the discussion in Issue #161 

Because there is a lot of text in the Application Layer:Type section of the Spec, I promoted some elements of the text so they would appear in the PDF Outline. If I didn't do this, users would be forced to use the list of figures to rapidly move to a desired point in the Spec.